### PR TITLE
Embed lineup panel in page

### DIFF
--- a/optimizerBridge.js
+++ b/optimizerBridge.js
@@ -18,6 +18,18 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         handleOptimizationRequest(request.data)
             .then(result => {
                 console.log('[CFL Optimizer] Optimization completed successfully');
+
+                // forward lineup to active tab for injection
+                chrome.tabs.query({active:true,currentWindow:true}, tabs=>{
+                    if(tabs && tabs[0]){
+                        chrome.tabs.sendMessage(tabs[0].id,{
+                            action:'lineupGenerated',
+                            success:true,
+                            lineup: result.players || result
+                        });
+                    }
+                });
+
                 sendResponse({
                     success: true,
                     lineup: result

--- a/popup.js
+++ b/popup.js
@@ -153,6 +153,17 @@ async function optimizeLineup(playerData) {
             if (response.success) {
                 saveLineupToStorage(response.lineup);
                 showResults(response.lineup, false, null, selectedEngine);
+
+                // forward lineup to content script to inject into page
+                chrome.tabs.query({active:true,currentWindow:true}, tabs=>{
+                    if(tabs && tabs[0]){
+                        chrome.tabs.sendMessage(tabs[0].id,{
+                            action:'lineupGenerated',
+                            success:true,
+                            lineup: response.lineup.players || response.lineup
+                        });
+                    }
+                });
             } else {
                 console.error('[CFL Optimizer] Optimization failed:', response.error);
                 showError(response.error || 'Optimization failed. Please try again.');


### PR DESCRIPTION
## Summary
- inject an optimizer panel in the page from `content.js`
- forward generated lineups from popup and background scripts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f076e96408330a1f0a4ec301eb8bc